### PR TITLE
feat: add an action that sets the launch configuration if not none

### DIFF
--- a/launch_ext/actions/__init__.py
+++ b/launch_ext/actions/__init__.py
@@ -3,9 +3,11 @@
 from .log_rotate import LogRotate
 from .include_package_launch_file import IncludePackageLaunchFile
 from .write_file import WriteFile
+from .set_launch_configuration_if_not_none import SetLaunchConfigurationIfNotNone
 
 __all__ = [
     'LogRotate',
     'IncludePackageLaunchFile'
-    'WriteFile'
+    'WriteFile',
+    'SetLaunchConfigurationIfNotNone'
 ]

--- a/launch_ext/actions/set_launch_configuration_if_not_none.py
+++ b/launch_ext/actions/set_launch_configuration_if_not_none.py
@@ -1,0 +1,11 @@
+import launch
+from launch.actions import SetLaunchConfiguration
+from launch.some_substitutions_type import SomeSubstitutionsType
+
+
+
+def SetLaunchConfigurationIfNotNone(name: str, value: SomeSubstitutionsType | None):
+    """
+    Set a launch configuration if the value is not None.
+    """
+    return SetLaunchConfiguration(name, value) if value is not None else launch.LaunchDescriptionEntity()


### PR DESCRIPTION
It _would_ be nice to use the `action.condition` but the `SetLaunchConfiguration` will fail if you pass it a `None` as this is executed before the condition is evaluated. Could make this a class but a function which looks like a class was simpler...