### PR TITLE
fix: Added missing example-interfaces dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
   <exec_depend>launch</exec_depend>
   <exec_depend>python3-psutil</exec_depend>
   <exec_depend>xacro</exec_depend>
-  <exec_depend>example-interfaces</exec_depend>
+  <exec_depend>example_interfaces</exec_depend>
   <exec_depend>python3-jinja2</exec_depend>
   <exec_depend>python3-git</exec_depend>
   <!-- <test_depend>ament_copyright</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <exec_depend>launch</exec_depend>
   <exec_depend>python3-psutil</exec_depend>
   <exec_depend>xacro</exec_depend>
+  <exec_depend>example-interfaces</exec_depend>
   <exec_depend>python3-jinja2</exec_depend>
   <exec_depend>python3-git</exec_depend>
   <!-- <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
Untested on local machine but should address #18 