### PR TITLE
Added missing pydantic dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>example_interfaces</exec_depend>
   <exec_depend>python3-jinja2</exec_depend>
   <exec_depend>python3-git</exec_depend>
+  <exec_depend>python3-pydantic</exec_depend>
   <!-- <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>


### PR DESCRIPTION
<img width="1240" height="60" alt="image" src="https://github.com/user-attachments/assets/0ad9c35e-724f-44ee-b121-ffebfd1a0eaa" />
Launch files were getting this error, this should fix