### PR TITLE
chore: bump mise actions to v5, unpin pixi-build-ros-gr backend

### DIFF
--- a/.github/workflows/test-pixi.yml
+++ b/.github/workflows/test-pixi.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: greenroom-robotics/mise/.github/actions/test@v4
+      - uses: greenroom-robotics/mise/.github/actions/test@v5
         with:
           package-dir: .
           gh-app-client-id: ${{ secrets.GH_APP_CLIENT_ID }}


### PR DESCRIPTION
Bump greenroom-robotics/mise composite actions to @v5, and change the pixi-build-ros-gr build backend version pin from `>=0.4,<0.5` to `*`.